### PR TITLE
switch from common fork/join pool to custom ExecutorService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,10 @@ subprojects {
     targetCompatibility = 1.8
 
     ext {
-        governatorVersion = '1.15.5'
+        governatorVersion = '1.15.7'
         archaiusVersion = '2.1.10'
         eurekaVersion = '1.6.0'
+        spectatorVersion = '0.43.0'
     }
 
     repositories { 

--- a/health-core/build.gradle
+++ b/health-core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile project(':health-api')
     compile 'javax.inject:javax.inject:1'
     compile "com.netflix.governator:governator-api:${governatorVersion}"
+    compile "com.netflix.spectator:spectator-api:${spectatorVersion}"
     
     testCompile "org.mockito:mockito-core:1.9.5"
 }

--- a/health-core/src/test/java/com/netflix/runtime/health/core/SimpleHealthCheckAggregatorMetricsTest.java
+++ b/health-core/src/test/java/com/netflix/runtime/health/core/SimpleHealthCheckAggregatorMetricsTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.runtime.health.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.netflix.governator.event.ApplicationEventDispatcher;
+import com.netflix.runtime.health.api.Health;
+import com.netflix.runtime.health.api.HealthIndicator;
+import com.netflix.runtime.health.api.HealthIndicatorCallback;
+import com.netflix.spectator.api.DefaultRegistry;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleHealthCheckAggregatorMetricsTest {
+
+    @Mock ApplicationEventDispatcher dispatcher;
+    DefaultRegistry registry;
+    SimpleHealthCheckAggregator aggregator;
+    
+    @Before
+    public void init() {
+        this.registry = new DefaultRegistry();
+    }
+    
+    static HealthIndicator nonResponsive = new HealthIndicator() {
+        @Override
+        public void check(HealthIndicatorCallback healthCallback) {
+        }
+    };
+        
+    static HealthIndicator exceptional = new HealthIndicator() {
+        @Override
+        public void check(HealthIndicatorCallback healthCallback) {
+            throw new RuntimeException("Boom");
+        }
+    };
+
+    static HealthIndicator unhealthy = new HealthIndicator() {
+        @Override
+        public void check(HealthIndicatorCallback healthCallback) {
+            healthCallback.inform(Health.unhealthy().build());
+        }
+    };
+
+    static HealthIndicator healthy = new HealthIndicator() {
+        @Override
+        public void check(HealthIndicatorCallback healthCallback) {
+            healthCallback.inform(Health.healthy().build());
+        }
+    };
+    
+    @Test(timeout=1000)
+    public void testHealthyIsRecorded() throws Exception {
+        aggregator = new SimpleHealthCheckAggregator(Arrays.asList(healthy), 1, TimeUnit.SECONDS, dispatcher, registry);
+        aggregator.check().get();
+        assertEquals(1, registry.counter("runtime.health", "status", "HEALTHY").count());
+    }
+    
+    @Test(timeout=1000)
+    public void testUnHealthyIsRecorded() throws Exception {
+        aggregator = new SimpleHealthCheckAggregator(Arrays.asList(unhealthy), 1, TimeUnit.SECONDS, dispatcher, registry);
+        aggregator.check().get();
+        assertEquals(1, registry.counter("runtime.health", "status", "UNHEALTHY").count());
+    }
+    
+    @Test(timeout=1000)
+    public void testTimeoutIsRecorded() throws Exception {
+        aggregator = new SimpleHealthCheckAggregator(Arrays.asList(nonResponsive), 50, TimeUnit.MILLISECONDS, dispatcher, registry);
+        aggregator.check().get();
+        assertEquals(1, registry.counter("runtime.health", "status", "TIMEOUT").count());
+    }
+}


### PR DESCRIPTION
add spectator logging for health
update governator to 1.15.7