### PR TITLE
Fix dependencies scope in generated POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript { repositories { jcenter() } } 
 
 plugins {
-    id 'nebula.netflixoss' version '3.2.3'
+    id 'nebula.netflixoss' version '6.0.4'
 }
 
 // Establish version and status

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
In Gradle 5.0, `compileClassPath` and `runtimeClassPath` are different.

Current generated POM (http://central.maven.org/maven2/com/netflix/runtime/health-integrations/1.1.3/health-integrations-1.1.3.pom) adds the dependencies as `runtime`

```
<dependency>
<groupId>com.netflix.runtime</groupId>
<artifactId>health-core</artifactId>
<version>1.1.3</version>
<scope>runtime</scope>
</dependency>
```

This break library consumers in Gradle 5 if they use the library in compile for implementing their own `HealthIndicator`.

While this library hasn't changed in years, it requires a fix so consumers can go to Gradle 5.

Upgraded nebula netflixoss and gradle version

Here is a new generated POM after the change

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.netflix.runtime</groupId>
  <artifactId>health-integrations</artifactId>
  <version>1.2.0-SNAPSHOT</version>
  <name>health-integrations</name>
  <description>health-integrations</description>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>netflixgithub</id>
      <name>Netflix Open Source Development</name>
      <email>netflixoss@netflix.com</email>
    </developer>
  </developers>
  <dependencies>
    <dependency>
      <groupId>com.netflix.runtime</groupId>
      <artifactId>health-core</artifactId>
      <version>1.2.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.netflix.eureka</groupId>
      <artifactId>eureka-client</artifactId>
      <version>1.6.0</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.netflix.archaius</groupId>
      <artifactId>archaius2-core</artifactId>
      <version>2.1.10</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
  <properties>
    <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
    <nebula_Implementation_Title>com.netflix.runtime#health-integrations;1.2.0-SNAPSHOT</nebula_Implementation_Title>
    <nebula_Implementation_Version>1.2.0-SNAPSHOT</nebula_Implementation_Version>
    <nebula_Built_Status>integration</nebula_Built_Status>
    <nebula_Built_By>rperezalcolea</nebula_Built_By>
    <nebula_Built_OS>Mac OS X</nebula_Built_OS>
    <nebula_Build_Date>2018-10-15_15:34:51</nebula_Build_Date>
    <nebula_Gradle_Version>4.10.2</nebula_Gradle_Version>
    <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
    <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
    <nebula_Module_Source>/health-integrations</nebula_Module_Source>
    <nebula_Module_Origin>ssh://git@github.com/netflix/runtime-health.git</nebula_Module_Origin>
    <nebula_Created_By>1.8.0_181-b02 (Oracle Corporation)</nebula_Created_By>
    <nebula_Build_Java_Version>1.8.0_181</nebula_Build_Java_Version>
    <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
    <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
  </properties>
  <url>https://github.com/netflix/runtime-health</url>
  <scm>
    <url>ssh://git@github.com/netflix/runtime-health.git</url>
  </scm>
</project>
```